### PR TITLE
62 genres annotation (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ To fix import errors and other Intellisense features, make sure you've let VSCod
 
 ## Running code
 
-For development purposes, you can simply run the dev script: 
+For development purposes, you can simply run the dev script:
 
 ```
 pipenv run dev
 ```
 
-Be sure to specify options such as -v and -l *before* any subcommands (process, load, etc.).  
+Be sure to specify options such as -v and -l *before* any subcommands (process, load, etc.).
 
 **NOTE:** *If you encounter a ModuleNotFoundError, make sure you are in the root directory of the project, as the `mediabridge` directory is the module Pipenv is trying to reference.*
 

--- a/mediabridge/data_processing/interaction_matrix.py
+++ b/mediabridge/data_processing/interaction_matrix.py
@@ -13,7 +13,7 @@ def list_rating_files(directory_path):
 
 
 def create_interaction_matrix(directory_path, num_users, num_movies):
-    interaction_matrix = coo_matrix((num_users, num_movies), dtype=np.int8)
+    im = interaction_matrix = coo_matrix((num_users, num_movies), dtype=np.int8)
     user_mapper = {}
     current_user_index = 0
 
@@ -35,7 +35,7 @@ def create_interaction_matrix(directory_path, num_users, num_movies):
                     current_user_index += 1
 
                 user_idx = user_mapper[user_id]
-                interaction_matrix[user_idx, movie_idx] = rating
+                im[user_idx, movie_idx] = rating  # type: ignore [reportIndexIssue]
 
     return interaction_matrix
 

--- a/mediabridge/data_processing/wiki_to_netflix.py
+++ b/mediabridge/data_processing/wiki_to_netflix.py
@@ -223,9 +223,9 @@ def wiki_query(
         log.info(f'Found movie id {movie.netflix_id}: ("{movie.title}", {movie.year})')
         return EnrichedMovieData(
             **vars(movie),
-            wikidata_id=wiki_feature_info(data, "item"),
-            genres=wiki_feature_info(data, "genreLabel"),
-            director=wiki_feature_info(data, "directorLabel"),
+            wikidata_id=str(wiki_feature_info(data, "item")),
+            genres=wiki_feature_genres(data, "genreLabel"),
+            director=wiki_feature_optional_str(data, "directorLabel"),
         )
 
     log.warning(
@@ -233,7 +233,10 @@ def wiki_query(
     )
 
 
-def process_data(num_rows: int | None = None, output_missing_csv_path: Path = None):
+def process_data(
+    num_rows: int | None = None,
+    output_missing_csv_path: Path | None = None,
+) -> None:
     """
     Processes Netflix movie data by enriching it with information from Wikidata
     and writes the results to a CSV file.

--- a/mediabridge/data_processing/wiki_to_netflix.py
+++ b/mediabridge/data_processing/wiki_to_netflix.py
@@ -283,7 +283,7 @@ def process_data(
             log.warning(f"Skipping movie id {id}: (' {title} ', {year})")
             continue
 
-        netflix_data = MovieData(int(id), title, int(year))
+        netflix_data = MovieData(id, title, int(year))
         if wiki_data := wiki_query(netflix_data):
             # wiki_query finds match, add to processed data
             processed.append(wiki_data)

--- a/mediabridge/data_processing/wiki_to_netflix.py
+++ b/mediabridge/data_processing/wiki_to_netflix.py
@@ -111,8 +111,6 @@ def wiki_feature_optional_str(data: dict[str, Any], key: str) -> str | None:
 def wiki_feature_genres(data: dict[str, Any], key: str) -> list[str]:
     """Validates that we obtained some sensible movie genres."""
     genres = wiki_feature_info(data, key)
-    if not genres:
-        return []
     assert isinstance(genres, list)
     for genre in genres:
         assert isinstance(genre, str)
@@ -231,6 +229,7 @@ def wiki_query(
     log.warning(
         f'Could not find movie id {movie.netflix_id}: ("{movie.title}", {movie.year})'
     )
+    return None
 
 
 def process_data(

--- a/mediabridge/data_processing/wiki_to_netflix_test.py
+++ b/mediabridge/data_processing/wiki_to_netflix_test.py
@@ -1,16 +1,16 @@
-import mediabridge.data_processing.wiki_to_netflix as w2n
+import mediabridge.data_processing.wiki_to_netflix as w_to_n
 from mediabridge.data_processing.wiki_to_netflix_test_data import EXPECTED_SPARQL_QUERY
 from mediabridge.schemas.movies import EnrichedMovieData, MovieData
 
 
 def test_format_sparql_query():
-    QUERY = w2n.format_sparql_query("The Room", 2003)
+    QUERY = w_to_n.format_sparql_query("The Room", 2003)
     assert QUERY == EXPECTED_SPARQL_QUERY
 
 
 def test_wiki_query():
     movie = MovieData("0", "The Room", 2003)
-    result = w2n.wiki_query(movie)
+    result = w_to_n.wiki_query(movie)
 
     # Order of genres is not guaranteed, so we sort before checking for equality
     result.genres = sorted(result.genres)

--- a/mediabridge/data_processing/wiki_to_netflix_test.py
+++ b/mediabridge/data_processing/wiki_to_netflix_test.py
@@ -11,6 +11,7 @@ def test_format_sparql_query():
 def test_wiki_query():
     movie = MovieData("0", "The Room", 2003)
     result = w_to_n.wiki_query(movie)
+    assert result
 
     # Order of genres is not guaranteed, so we sort before checking for equality
     result.genres = sorted(result.genres)

--- a/mediabridge/db/load.py
+++ b/mediabridge/db/load.py
@@ -29,7 +29,7 @@ def load():
         for row in reader:
             netflix_id, title, year, wikidata_id, genres, director = row
             movie = EnrichedMovieData(
-                int(netflix_id),
+                netflix_id,
                 title,
                 int(year),
                 wikidata_id,

--- a/mediabridge/db/load.py
+++ b/mediabridge/db/load.py
@@ -4,8 +4,8 @@ import logging
 
 from typer import Typer
 
-from mediabridge.schemas import EnrichedMovieData
 from mediabridge.definitions import OUTPUT_DIR
+from mediabridge.schemas import EnrichedMovieData
 
 log = logging.getLogger(__name__)
 app = Typer()
@@ -27,7 +27,15 @@ def load():
             )
 
         for row in reader:
-            movie = EnrichedMovieData(*row)
+            netflix_id, title, year, wikidata_id, genres, director = row
+            movie = EnrichedMovieData(
+                int(netflix_id),
+                title,
+                int(year),
+                wikidata_id,
+                genres.split(";"),
+                director,
+            )
             log.info(f"Inserting {movie} into MongoDB")
             # TODO: Needs implementation, bulk inserts for performance
 

--- a/mediabridge/schemas/movies.py
+++ b/mediabridge/schemas/movies.py
@@ -6,7 +6,7 @@ from typing import Optional
 class MovieData:
     """Dataclass for known data from the Netflix dataset"""
 
-    netflix_id: int
+    netflix_id: str
     title: str
     year: int
 
@@ -24,5 +24,5 @@ class EnrichedMovieData(MovieData):
     """Dataclass for enriched data from a Wikidata match"""
 
     wikidata_id: str
-    genres: Optional[list[str]]
+    genres: list[str]  # possibly an empty list
     director: Optional[str]

--- a/mediabridge/schemas/movies_test.py
+++ b/mediabridge/schemas/movies_test.py
@@ -3,7 +3,7 @@ from mediabridge.schemas.movies import EnrichedMovieData
 
 def test_flatten_values():
     vals = EnrichedMovieData(
-        1, "The Matrix", 1999, "Q11424", ["Action", "Drama"], "Lana Wachowski"
+        "1", "The Matrix", 1999, "Q11424", ["Action", "Drama"], "Lana Wachowski"
     ).flatten_values()
     assert vals == {
         "netflix_id": "1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+
+[project]
+name = "MediaBridge"
+version = "0.0.1"
+requires-python = ">=3.10"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+float_to_top =            true
+include_trailing_comma =  true
+multi_line_output =       "VERTICAL_HANGING_INDENT"
+line_length =             88
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E4", "E7", "E9", "A", "ANN", "ARG", "ASYNC", "B", "BLE", "C", "C4", "C90", "COM",
+    "DTZ", "E", "EM", "EXE", "F", "FBT", "FIX", "FURB", "G", "ICN", "INT", "ISC",
+    "LOG", "N", "NPY", "PERF", "PIE", "PTH", "PYI", "Q", "RET", "RSE", "RUF",
+    "SIM", "SLF", "SLOT", "TCH", "TID", "TRY", "UP", "W", "YTT",
+]


### PR DESCRIPTION
* Add type impedance matchers: wiki_feature_optional_str & wiki_feature_genres

* Decline to produce zero-byte CSV if we're given zero movies

* Break out finding the various fieldnames

* In wiki_query(), address mypy diagnostic: error: Missing return statement [return]

* In the process_data() signature, replace "x: Foo = None", preferring "x: Foo | None = None"

* EnrichedMovieData accepts some types which are not "str"

* Suppress diagnostic in create_interaction_matrix(): error: "__setitem__" method not defined on type "coo_matrix" (reportIndexIssue)

* Ensure that num_rows is an integer, even if it is zero