### PR TITLE
Make wiki_to_netflix_test hermetic

### DIFF
--- a/mediabridge/data_processing/wiki_to_netflix_test.py
+++ b/mediabridge/data_processing/wiki_to_netflix_test.py
@@ -1,17 +1,22 @@
 import unittest
+from unittest.mock import patch
 
 import mediabridge.data_processing.wiki_to_netflix as w_to_n
-from mediabridge.data_processing.wiki_to_netflix_test_data import EXPECTED_SPARQL_QUERY
+from mediabridge.data_processing.wiki_to_netflix_test_data import (
+    EXPECTED_SPARQL_QUERY,
+    WIKIDATA_RESPONSE_THE_ROOM,
+)
 from mediabridge.schemas.movies import EnrichedMovieData, MovieData
 
 
 class TestWikiToNetflix(unittest.TestCase):
-    def test_format_sparql_query(self) -> None:
+    def test_format_sparql_query(self):
         QUERY = w_to_n.format_sparql_query("The Room", 2003)
         assert QUERY == EXPECTED_SPARQL_QUERY
 
-    def test_wiki_query(self) -> None:
-        # Integration test -- this hits the wikidata.org webserver.
+    @patch("mediabridge.data_processing.wiki_to_netflix.requests")
+    def test_wiki_query(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = WIKIDATA_RESPONSE_THE_ROOM
         movie = MovieData("0", "The Room", 2003)
         result = w_to_n.wiki_query(movie)
         assert result

--- a/mediabridge/data_processing/wiki_to_netflix_test_data.py
+++ b/mediabridge/data_processing/wiki_to_netflix_test_data.py
@@ -43,3 +43,124 @@ EXPECTED_SPARQL_QUERY = """
             }
     
         """
+
+WIKIDATA_RESPONSE_THE_ROOM = {
+    "head": {
+        "vars": [
+            "item",
+            "releaseDateStatement",
+            "releaseDate",
+            "itemLabel",
+            "genre",
+            "genreLabel",
+            "director",
+            "directorLabel",
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "item": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q533383",
+                },
+                "director": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q860114",
+                },
+                "directorLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Tommy Wiseau",
+                },
+                "genre": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q1054574",
+                },
+                "genreLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "romance film",
+                },
+                "releaseDateStatement": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/statement/Q533383-EE3D4972-4B06-4B0D-869B-23504D828AE6",
+                },
+                "releaseDate": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2003-06-27T00:00:00Z",
+                },
+                "itemLabel": {"xml:lang": "en", "type": "literal", "value": "The Room"},
+            },
+            {
+                "item": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q533383",
+                },
+                "director": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q860114",
+                },
+                "directorLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Tommy Wiseau",
+                },
+                "genre": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q459290",
+                },
+                "genreLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "independent film",
+                },
+                "releaseDateStatement": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/statement/Q533383-EE3D4972-4B06-4B0D-869B-23504D828AE6",
+                },
+                "releaseDate": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2003-06-27T00:00:00Z",
+                },
+                "itemLabel": {"xml:lang": "en", "type": "literal", "value": "The Room"},
+            },
+            {
+                "item": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q533383",
+                },
+                "director": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q860114",
+                },
+                "directorLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Tommy Wiseau",
+                },
+                "genre": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q130232",
+                },
+                "genreLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "drama film",
+                },
+                "releaseDateStatement": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/statement/Q533383-EE3D4972-4B06-4B0D-869B-23504D828AE6",
+                },
+                "releaseDate": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2003-06-27T00:00:00Z",
+                },
+                "itemLabel": {"xml:lang": "en", "type": "literal", "value": "The Room"},
+            },
+        ]
+    },
+}


### PR DESCRIPTION
Unit tests should be hermetic. They should not make any network requests. They should not depend on an external API.

This is for multiple reasons:

1. Network calls are inherently unreliable. Making network calls in unit tests will make them flaky. This might not be apparently when only doing one or two, but when a test suite grows to 1000 tests, it will get increasingly harder to run the test suite successfully
2. Tests which require network calls also require that developers who wish to work on the project be online, which is not always possible or desirable. Hermetic unit tests mean that the code can be worked on without a network connection.
3. We may wish to run our unit tests in CI environments that we do not control. Therefore, we are not able to guarantee the composition or topology of the network in those environments.

It is definitely the case that we want to know when, for instance, the Wikidata API changes in a way that breaks our code. If Wikidata starts returning extra fields that break us, or omits data we need, etc, we should respond accordingly. However, this should not be discovered in _unit_ tests. This is the subject for separate, integration/end-to-end tests. The unit tests should verify that given a certain input (including input from an external API), the code under test performs in an expected way.