### PR TITLE
76 enable   strict mode

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -7,6 +7,6 @@ source bin/util.sh
 
 ${ENV} ruff check .
 
-${ENV} mypy ${STRICT} --show-traceback --warn-unreachable --ignore-missing-imports --no-namespace-packages .
+${ENV} mypy --strict --show-traceback --warn-unreachable --ignore-missing-imports --no-namespace-packages .
 
 ${ENV} pyright .

--- a/mediabridge/db/connect.py
+++ b/mediabridge/db/connect.py
@@ -1,19 +1,20 @@
-# MongoDB connection setup
 import os
 from functools import cache
+from typing import Any
 
 from dotenv import load_dotenv
 from pymongo import MongoClient
+from pymongo.database import Database
 
 load_dotenv()
 
 
 @cache
-def connect_to_mongo():
+def connect_to_mongo() -> Database[Any]:
     # This will raise an exception if MONGODB_URI is not defined in the environment.
     # If that isn't enough information to help developers populate their environment,
     # we should use `get` and throw a custom message if the value is missing.
     mongo_uri = os.environ["MONGODB_URI"]
-    client = MongoClient(mongo_uri)
+    client: MongoClient[Any] = MongoClient(mongo_uri)
     db = client["mediabridge"]
     return db

--- a/mediabridge/db/load.py
+++ b/mediabridge/db/load.py
@@ -12,7 +12,7 @@ app = Typer()
 
 
 @app.command()
-def load():
+def load() -> None:
     """
     Load a csv of movie data into the mongo database.
     """

--- a/mediabridge/db/queries.py
+++ b/mediabridge/db/queries.py
@@ -1,7 +1,14 @@
+from typing import Any
+
+from pymongo.database import Database
+from pymongo.operations import InsertOne, UpdateOne
+
 from mediabridge.db.connect import connect_to_mongo
 
+MovieDoc = dict[str, str | int]
 
-def insert_into_mongo(movie):
+
+def insert_into_mongo(movie: list[str | int]) -> None:
     db = connect_to_mongo()
     collection = db["movies"]
     collection.update_one(
@@ -20,7 +27,7 @@ def insert_into_mongo(movie):
     )
 
 
-def bulk_insert(operations):
-    db = connect_to_mongo()
+def bulk_insert(operations: list[UpdateOne | InsertOne[MovieDoc]]) -> None:
+    db: Database[Any] = connect_to_mongo()
     collection = db["movies"]
     collection.bulk_write(operations)

--- a/mediabridge/main.py
+++ b/mediabridge/main.py
@@ -27,7 +27,7 @@ def main(
     log: bool = typer.Option(
         False, "--log", "-l", help="Enable all logging message levels and log to file."
     ),
-):
+) -> None:
     if not OUTPUT_DIR.exists():
         print(
             f"[WARNING] Output directory does not exist, creating new directory at {OUTPUT_DIR}"

--- a/mediabridge/schemas/movies.py
+++ b/mediabridge/schemas/movies.py
@@ -9,7 +9,7 @@ class MovieData:
     title: str
     year: int
 
-    def flatten_values(self):
+    def flatten_values(self) -> dict[str, str]:
         """Format all dataclass fields into a mapping of strings by joining
         lists with semicolons"""
         return {

--- a/mediabridge/schemas/movies_test.py
+++ b/mediabridge/schemas/movies_test.py
@@ -1,7 +1,7 @@
 from mediabridge.schemas.movies import EnrichedMovieData
 
 
-def test_flatten_values():
+def test_flatten_values() -> None:
     vals = EnrichedMovieData(
         "1", "The Matrix", 1999, "Q11424", ["Action", "Drama"], "Lana Wachowski"
     ).flatten_values()


### PR DESCRIPTION
"A small PR is a beautiful PR."
This one has limited scope, and touches only a handful of files, making it easier to approve. It enables `mypy --strict`, so that authors may be reminded to annotate the signatures of newly added functions.
No functional changes. We are merely changing the type hints.