### PR TITLE
110 write a failing test

### DIFF
--- a/mediabridge/data_processing/etl.py
+++ b/mediabridge/data_processing/etl.py
@@ -140,7 +140,7 @@ def _validate_rating_table() -> None:
     with Session(get_engine()) as sess:
         # We expect strictly numeric data here, not a column heading text label.
         q = sess.query(Rating).filter(Rating.user_id == "user_id")
-        assert 0 == len(list(q.all()))
+        assert 0 == len(list(q.all())), "Rating table contained header row"
 
 
 def _get_input_csv(max_rows: int, all_rows: int = 100_480_507) -> Path:

--- a/mediabridge/data_processing/etl.py
+++ b/mediabridge/data_processing/etl.py
@@ -115,7 +115,7 @@ def _insert_ratings(csv: Path, max_rows: int) -> None:
         conn.execute(text("DROP TABLE  IF EXISTS  rating_csv"))
         conn.execute(text(create_rating_csv))
         conn.commit()
-        _run_sqlite_child(
+        run_sqlite_child(
             [
                 ".mode csv",
                 ".headers on",
@@ -150,7 +150,7 @@ def _get_input_csv(max_rows: int, all_rows: int = 100_480_507) -> Path:
     return Path(csv)
 
 
-def _run_sqlite_child(cmds: list[str]) -> None:
+def run_sqlite_child(cmds: list[str]) -> None:
     with Popen(
         ["sqlite3", DB_FILE],
         text=True,

--- a/mediabridge/data_processing/etl.py
+++ b/mediabridge/data_processing/etl.py
@@ -155,7 +155,6 @@ def run_sqlite_child(cmds: list[str]) -> None:
         ["sqlite3", DB_FILE],
         text=True,
         stdin=PIPE,
-        stdout=PIPE,
     ) as proc:
         assert isinstance(proc.stdin, io.TextIOWrapper)
         for cmd in cmds:

--- a/mediabridge/data_processing/etl.py
+++ b/mediabridge/data_processing/etl.py
@@ -102,21 +102,14 @@ def _etl_user_rating(max_reviews: int) -> None:
 
 def _insert_ratings(csv: Path, max_rows: int) -> None:
     """Populates rating table from CSV, if needed."""
-    create_rating_csv = """
-        CREATE TABLE rating_csv (
-            user_id   INTEGER  NOT NULL,
-            rating    INTEGER  NOT NULL,
-            movie_id  TEXT     NOT NULL)
-    """
+
     ins = "INSERT INTO rating  SELECT user_id, movie_id, rating  FROM rating_csv  ORDER BY 1, 2, 3"
     with get_engine().connect() as conn:
         print(f"\n{max_rows:_}", end="", flush=True)
         t0 = time()
-        conn.execute(text("DROP TABLE  IF EXISTS  rating_csv"))
-        conn.execute(text(create_rating_csv))
-        conn.commit()
         run_sqlite_child(
             [
+                "DROP TABLE  IF EXISTS  rating_csv;",
                 ".mode csv",
                 ".headers on",
                 f".import {_get_input_csv(max_rows)} rating_csv",

--- a/tests/data_processing/etl_test.py
+++ b/tests/data_processing/etl_test.py
@@ -1,0 +1,31 @@
+import unittest
+from pathlib import Path
+
+import pandas as pd
+
+from mediabridge.data_processing.etl import _run_sqlite_child
+
+
+class EtlTest(unittest.TestCase):
+    def test_run_sqlite_child(self) -> None:
+        _run_sqlite_child(
+            [
+                "DROP TABLE  IF EXISTS  temp_table;",
+                "CREATE TABLE temp_table AS SELECT 123 AS num, 'abc' AS alpha;",
+                "DROP TABLE temp_table;",
+            ]
+        )
+
+    def test_sqlite_dot_import(self) -> None:
+        foo = pd.DataFrame([{"num": 123, "alpha": "abc"}])
+        csv = Path("/tmp/foo.csv")
+        foo.to_csv(csv, index=False)
+        _run_sqlite_child(
+            [
+                "DROP TABLE  IF EXISTS  foo;",
+                ".mode csv",
+                ".headers off",
+                f".import {csv} foo",
+            ]
+        )
+        csv.unlink()

--- a/tests/data_processing/etl_test.py
+++ b/tests/data_processing/etl_test.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session
 
 from mediabridge.data_processing.etl import run_sqlite_child
-from mediabridge.db.tables import get_engine
+from mediabridge.db.tables import create_tables, get_engine
 
 
 class EtlTest(unittest.TestCase):
@@ -15,6 +15,7 @@ class EtlTest(unittest.TestCase):
         df = pd.DataFrame([{"num": 123, "alpha": "abc"}])
         csv = Path("/tmp/foo.csv")
         df.to_csv(csv, index=False)
+        create_tables()
         run_sqlite_child(
             [
                 "DROP TABLE  IF EXISTS  foo;",

--- a/tests/data_processing/etl_test.py
+++ b/tests/data_processing/etl_test.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 import pandas as pd
 
-from mediabridge.data_processing.etl import _run_sqlite_child
+from mediabridge.data_processing.etl import run_sqlite_child
 
 
 class EtlTest(unittest.TestCase):
     def test_run_sqlite_child(self) -> None:
-        _run_sqlite_child(
+        run_sqlite_child(
             [
                 "DROP TABLE  IF EXISTS  temp_table;",
                 "CREATE TABLE temp_table AS SELECT 123 AS num, 'abc' AS alpha;",
@@ -20,7 +20,7 @@ class EtlTest(unittest.TestCase):
         foo = pd.DataFrame([{"num": 123, "alpha": "abc"}])
         csv = Path("/tmp/foo.csv")
         foo.to_csv(csv, index=False)
-        _run_sqlite_child(
+        run_sqlite_child(
             [
                 "DROP TABLE  IF EXISTS  foo;",
                 ".mode csv",

--- a/tests/data_processing/etl_test.py
+++ b/tests/data_processing/etl_test.py
@@ -48,3 +48,15 @@ class EtlTest(unittest.TestCase):
                 list(sess.query(Foo).all()),
             )
         csv.unlink()
+
+        # https://sqlite.org/cli.html
+        # 7.5. Importing files as CSV or other formats
+        # When .import is run, its treatment of the first input row depends upon
+        # whether the target table already exists. If it does not exist, the table
+        # is automatically created and the content of the first input row is used
+        # to set the name of all the columns in the table. In this case, the table
+        # data content is taken from the second and subsequent input rows. If the
+        # target table already exists, every row of the input, including the
+        # first, is taken to be actual data content. If the input file contains an
+        # initial row of column labels, you can make the .import command skip that
+        # initial row using the "--skip 1" option.

--- a/tests/data_processing/etl_test.py
+++ b/tests/data_processing/etl_test.py
@@ -2,30 +2,49 @@ import unittest
 from pathlib import Path
 
 import pandas as pd
+from sqlalchemy.ext.automap import automap_base
+from sqlalchemy.orm import Session
 
 from mediabridge.data_processing.etl import run_sqlite_child
+from mediabridge.db.tables import get_engine
 
 
 class EtlTest(unittest.TestCase):
-    def test_run_sqlite_child(self) -> None:
-        run_sqlite_child(
-            [
-                "DROP TABLE  IF EXISTS  temp_table;",
-                "CREATE TABLE temp_table AS SELECT 123 AS num, 'abc' AS alpha;",
-                "DROP TABLE temp_table;",
-            ]
-        )
 
     def test_sqlite_dot_import(self) -> None:
-        foo = pd.DataFrame([{"num": 123, "alpha": "abc"}])
+        df = pd.DataFrame([{"num": 123, "alpha": "abc"}])
         csv = Path("/tmp/foo.csv")
-        foo.to_csv(csv, index=False)
+        df.to_csv(csv, index=False)
         run_sqlite_child(
             [
                 "DROP TABLE  IF EXISTS  foo;",
                 ".mode csv",
-                ".headers off",
                 f".import {csv} foo",
             ]
         )
+        Base = automap_base()
+        Base.prepare(autoload_with=get_engine())
+        Foo = Base.metadata.tables["foo"]
+
+        with Session(get_engine()) as sess:
+            self.assertListEqual(
+                [
+                    ("123", "abc"),
+                ],
+                list(sess.query(Foo).all()),
+            )
+            run_sqlite_child(
+                [
+                    "DELETE FROM foo;",  # NB: no DROP, this time
+                    ".mode csv",
+                    f".import {csv} foo",
+                ]
+            )
+            self.assertListEqual(  # Now the .import behavior is to INSERT header as data                [
+                [
+                    ("num", "alpha"),
+                    ("123", "abc"),
+                ],
+                list(sess.query(Foo).all()),
+            )
         csv.unlink()

--- a/tests/recommender/two_movies_rec_test.py
+++ b/tests/recommender/two_movies_rec_test.py
@@ -1,8 +1,5 @@
 import unittest
-from time import time
 
-from mediabridge.data_processing.etl import etl
-from mediabridge.db.tables import create_tables
 from mediabridge.definitions import TITLES_TXT
 from mediabridge.recommender.make_recommendation import get_title, recommend
 

--- a/tests/recommender/two_movies_rec_test.py
+++ b/tests/recommender/two_movies_rec_test.py
@@ -24,24 +24,6 @@ class TestTwoMoviesRec(unittest.TestCase):
     # Ideally we should be able to have a user supply two movies they like,
     # and recommend a few more to them. We're not quite there yet.
 
-    def test_etl(self) -> None:
-        # We might choose another way to run the ETL, outside of a test framework.
-        # The current code was enough to support an edit-run cycle during initial development.
-
-        # For example, tests may run in arbitrary order, yet recommend() depends on ETL.
-        # ETL effects persist across test runs, so a failed initial run will let later tests succeed.
-
-        create_tables()
-        if TITLES_TXT.exists():
-            # A million rows corresponds to a four-second ETL.
-            t0 = time()
-
-            etl(max_reviews=1_000_000, regen=True)
-
-            elapsed = time() - t0
-            x = (elapsed < 10) or print(f"ETL finished in {elapsed:.3f} s")
-            assert x in (True, None)  # we simply evaluated for side effects
-
     def test_recommend(self) -> None:
         if TITLES_TXT.exists():
             ids = _clean(recommend())


### PR DESCRIPTION
In working with various DB backends there's a pair of things I've become accustomed to:
- postgres COPY and mariadb LOAD FILE behave quite predictably (and fast)
- typically I'll want to pre-create a zero-row table with suitable schema, constraints, indexes

I mis-applied these lessons in a sqlite context. It turns out the documented behavior
of `.import` is quite different based on whether target table already exists or not.
I found this, ummm, surprising; it's a tool that may work today and bite you tomorrow.
This PR does a Root Cause Analysis and fixes my breakage, ensuring it never crops up again, by changing both test and target code.
It preserves the .CSV text header line, so Pandas and other programmatic consumers can treat the file as "self-describing".

----

Reviewer's guide:
- In the ETL target code, we do **not** pre-create the rating_csv table (so, alas, we can't specify that some fields are numeric, but that's fine).
- In the target code we `_validate_rating_table()` so this regrettable effect can't crop up in production.
- We display the CLI tool's stdout, which made no difference and proved convenient for debugging.
- We introduce "a failing (Red) test" which highlights how `.import` behaves differently according to whether destination table already exists. Plus there's a docs citation.
- Prefer to `run mb load` rather than test_etl(). Therefore the test method is deleted, and it cannot leave behind a "short" rating table.