### PR TITLE
Add mypy config to pyproject.toml

### DIFF
--- a/bin/lint.sh
+++ b/bin/lint.sh
@@ -48,7 +48,7 @@ fi
 
 # If there is no value for "--only", or there is and it equals "mypy"
 if [[ -x "$only_value" || "$only_value" == "mypy" ]]; then
-  cmd=${ENV} mypy --strict --show-traceback --warn-unreachable --ignore-missing-imports --no-namespace-packages .
+  cmd=${ENV} mypy .
   echo $cmd
   $cmd
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,10 @@ select = [
     "LOG", "N", "NPY", "PERF", "PIE", "PTH", "PYI", "Q", "RET", "RSE", "RUF",
     "SIM", "SLF", "SLOT", "TCH", "TID", "TRY", "UP", "W", "YTT",
 ]
+
+[tool.mypy]
+strict = true
+show_traceback = true
+warn_unreachable = true
+ignore_missing_imports = true 
+no_namespace_packages = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ select = [
 
 [tool.mypy]
 strict = true
-show_traceback = true
 warn_unreachable = true
 ignore_missing_imports = true 
 no_namespace_packages = true


### PR DESCRIPTION
In a future PR, presumably after #141 has landed, we can clean up `lint.sh` to remove the redundant options.