### PR TITLE
Flask tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     }
-  }
+  },
+  "editor.indentSize": "tabSize"
 }

--- a/mediabridge/api/app.py
+++ b/mediabridge/api/app.py
@@ -15,7 +15,7 @@ db = SQLAlchemy()
 # Please consider the arguments in
 # https://flask.palletsprojects.com/en/stable/patterns/appfactories
 # when making edits to the create_app() function.
-def create_app(config_name=None) -> Flask:
+def create_app(config_name: str | None = None) -> Flask:
     if config_name is None:
         config_name = os.environ.get("FLASK_ENV", "development")
     config = ENV_TO_CONFIG.get(config_name)

--- a/mediabridge/api/app.py
+++ b/mediabridge/api/app.py
@@ -7,9 +7,10 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import text
 
 from mediabridge.config.backend import ENV_TO_CONFIG
+from mediabridge.db.tables import Base
 
 typer_app = typer.Typer()
-db = SQLAlchemy()
+db = SQLAlchemy(model_class=Base)
 
 
 # Please consider the arguments in

--- a/mediabridge/api/app_test.py
+++ b/mediabridge/api/app_test.py
@@ -1,10 +1,11 @@
+from flask.testing import FlaskClient
 from sqlalchemy import text
 
 from mediabridge.api.app import create_app, db
 
 
 class MovieSearchTest:
-    def _insert_movies(self):
+    def _insert_movies(self) -> None:
         with db.engine.connect() as conn:
             conn.execute(
                 text("""
@@ -17,20 +18,18 @@ class MovieSearchTest:
             )
             conn.commit()
 
-    def test_create_app_cleanly(self):
+    def test_create_app_cleanly(self) -> None:
         create_app("testing")
 
-    def test_movie_search(self, client):
+    def test_movie_search(self, client: FlaskClient) -> None:
         self._insert_movies()
-        # Test the search_movies endpoint
         response = client.get("/api/v1/movie/search?q=Inception")
         assert response.status_code == 200
         data = response.get_json()
         assert data == [{"id": "1", "year": 2010, "title": "Inception"}]
 
-    def test_movie_search_multiple_results(self, client):
+    def test_movie_search_multiple_results(self, client: FlaskClient) -> None:
         self._insert_movies()
-        # Test the search_movies endpoint
         response = client.get("/api/v1/movie/search?q=tion")
         assert response.status_code == 200
         data = response.get_json()
@@ -39,15 +38,14 @@ class MovieSearchTest:
             {"id": "3", "year": 1994, "title": "The Shawshank Redemption"},
         ]
 
-    def test_movie_search_no_results(self, client):
+    def test_movie_search_no_results(self, client: FlaskClient) -> None:
         self._insert_movies()
-        # Test the search_movies endpoint with no results
         response = client.get("/api/v1/movie/search?q=NonExistentMovie")
         assert response.status_code == 200
         data = response.get_json()
         assert data == []
 
-    def test_movie_search_missing_query(self, client):
+    def test_movie_search_missing_query(self, client: FlaskClient) -> None:
         response = client.get("/api/v1/movie/search")
         assert response.status_code == 400
         data = response.get_json()

--- a/mediabridge/api/app_test.py
+++ b/mediabridge/api/app_test.py
@@ -1,0 +1,54 @@
+from sqlalchemy import text
+
+from mediabridge.api.app import create_app, db
+
+
+class MovieSearchTest:
+    def _insert_movies(self):
+        with db.engine.connect() as conn:
+            conn.execute(
+                text("""
+                INSERT INTO movie_title (id, year, title)
+                VALUES ('1', 2010, 'Inception'),
+                       ('2', 1999, 'The Matrix'),
+                       ('3', 1994, 'The Shawshank Redemption'),
+                       ('4', 1994, 'Toy Story')
+                """)
+            )
+            conn.commit()
+
+    def test_create_app_cleanly(self):
+        create_app("testing")
+
+    def test_movie_search(self, client):
+        self._insert_movies()
+        # Test the search_movies endpoint
+        response = client.get("/api/v1/movie/search?q=Inception")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data == [{"id": "1", "year": 2010, "title": "Inception"}]
+
+    def test_movie_search_multiple_results(self, client):
+        self._insert_movies()
+        # Test the search_movies endpoint
+        response = client.get("/api/v1/movie/search?q=tion")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data == [
+            {"id": "1", "year": 2010, "title": "Inception"},
+            {"id": "3", "year": 1994, "title": "The Shawshank Redemption"},
+        ]
+
+    def test_movie_search_no_results(self, client):
+        self._insert_movies()
+        # Test the search_movies endpoint with no results
+        response = client.get("/api/v1/movie/search?q=NonExistentMovie")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data == []
+
+    def test_movie_search_missing_query(self, client):
+        response = client.get("/api/v1/movie/search")
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data == {"error": "Query parameter 'q' is required."}

--- a/mediabridge/api/conftest.py
+++ b/mediabridge/api/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+from mediabridge.api.app import create_app, db
+
+
+@pytest.fixture
+def app():
+    """Instantiate the Flask app for testing and yield it.
+
+    This fixture creates a new Flask app instance for each test, sets up the
+    database, and tears it down after the test is complete.
+    """
+    app = create_app("testing")
+
+    with app.app_context():
+        # Create the database tables (this is an empty in-memory database)
+        db.create_all()
+
+        # By yielding the app, we provide the current value to tests which
+        # use this fixture. After the test is done, the rest of the code in this
+        # function is executed.
+        yield app
+
+        # Drop everything, so the next test starts with a clean slate
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client for the Flask app and yield it.
+
+    By using yield, we ensure that the test using this fixture is running
+    inside of the test_client contenxt, which allows us to make requests to the
+    app and get responses back.
+
+    Note that this fixture itself depends on the app fixture.
+    """
+    with app.test_client() as client:
+        yield client

--- a/mediabridge/api/conftest.py
+++ b/mediabridge/api/conftest.py
@@ -1,10 +1,13 @@
+from typing import Generator
+
 import pytest
+from flask import Flask
+from flask.testing import FlaskClient
 
 from mediabridge.api.app import create_app, db
 
 
-@pytest.fixture
-def app():
+def app() -> Generator[Flask, None, None]:
     """Instantiate the Flask app for testing and yield it.
 
     This fixture creates a new Flask app instance for each test, sets up the
@@ -26,7 +29,7 @@ def app():
 
 
 @pytest.fixture
-def client(app):
+def client(app: Flask) -> Generator[FlaskClient, None, None]:
     """Create a test client for the Flask app and yield it.
 
     By using yield, we ensure that the test using this fixture is running

--- a/mediabridge/api/conftest.py
+++ b/mediabridge/api/conftest.py
@@ -7,6 +7,7 @@ from flask.testing import FlaskClient
 from mediabridge.api.app import create_app, db
 
 
+@pytest.fixture
 def app() -> Generator[Flask, None, None]:
     """Instantiate the Flask app for testing and yield it.
 

--- a/mediabridge/main.py
+++ b/mediabridge/main.py
@@ -125,7 +125,7 @@ def tf_idf(
     beta: float = typer.Option(0.7),
     gamma: float = typer.Option(2.0),
     top_k: int = typer.Option(5),
-):
+) -> None:
     url = "http://ollama.tomato-pepper.uk/movie_titles_plus_descriptions.jsonl"
     raw_data_path = DATA_DIR / "movie_titles_plus_descriptions.jsonl"
     df_path = DATA_DIR / "tf_idf_dataframe.csv"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 python_files = *_test.py
+python_classes = '*Test'


### PR DESCRIPTION
Write the first tests for the Flask app, using pytest fixtures. Hopefully this demonstrates how easy testing can be, once it is set up properly. It can be difficult to understand all of the options for pytest with fixtures, but this basic setup is all that we really need. The key is that each fixture (`app` and `client`) are `yield`ed to the required functions, which means that the test functions operate in the same context (like "Context Manager" context) as was active when the yield was called.